### PR TITLE
Fix retriever only training

### DIFF
--- a/dalm/training/rag_e2e/train_rage2e.py
+++ b/dalm/training/rag_e2e/train_rage2e.py
@@ -95,19 +95,13 @@ def parse_args() -> Namespace:
     parser.add_argument(
         "--per_device_train_batch_size",
         type=int,
-        default=8,
+        default=32,
         help="Batch size (per device) for the training dataloader.",
-    )
-    parser.add_argument(
-        "--per_device_eval_batch_size",
-        type=int,
-        default=8,
-        help="Batch size (per device) for the evaluation dataloader.",
     )
     parser.add_argument(
         "--learning_rate",
         type=float,
-        default=5e-5,
+        default=1e-4,
         help="Initial learning rate (after the potential warmup period) to use.",
     )
     parser.add_argument(
@@ -152,7 +146,7 @@ def parse_args() -> Namespace:
     parser.add_argument(
         "--num_warmup_steps",
         type=int,
-        default=0,
+        default=100,
         help="Number of steps for the warmup in the lr scheduler.",
     )
     parser.add_argument("--output_dir", type=str, default=None, help="Where to store the final model.")
@@ -480,7 +474,11 @@ def main() -> None:
 if __name__ == "__main__":
     main()
 
-
-# python train_rage2e.py  --dataset_path "./dataset" --retriever_name_or_path "BAAI/bge-small-en" \
-#   --generator_name_or_path "tiiuae/falcon-7b"   --output_dir "./contrastive_checkpoints" --use_peft  \
-#   --with_tracking --report_to tensorboard
+# python dalm/training/rag_e2e/train_rage2e.py
+#   --dataset_path "/root/DALM/dataset/out/question_answer_pairs_train"
+#   --retriever_name_or_path "BAAI/bge-large-en"
+#   --generator_name_or_path "meta-llama/Llama-2-7b-hf"
+#   --output_dir "./rag_e2e_checkpoints"
+#   --with_tracking
+#   --report_to all
+#   --per_device_train_batch_size 32

--- a/dalm/training/utils/rag_e2e_training_utils.py
+++ b/dalm/training/utils/rag_e2e_training_utils.py
@@ -12,9 +12,12 @@ def preprocess_dataset(
     dataset_passage_col_name: str,
     dataset_answer_col_name: str,
 ) -> Dict[str, Any]:
-    queries = examples[dataset_query_col_name]
-    passages = examples[dataset_passage_col_name]
+    querie_list = examples[dataset_query_col_name]
+    passage_list = examples[dataset_passage_col_name]
     answers = examples[dataset_answer_col_name]
+
+    queries = [f"#query# {query}" for query in querie_list]
+    passages = [f"#passage# {passage}" for passage in passage_list]
 
     # Tokenization for the retriever
     retriever_query_tokens = retriever_tokenizer(queries, padding="max_length", max_length=128, truncation=True)

--- a/dalm/training/utils/retriever_only_training_utils.py
+++ b/dalm/training/utils/retriever_only_training_utils.py
@@ -6,14 +6,19 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 
 def preprocess_dataset(
-    examples: LazyBatch, tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast
+    examples: LazyBatch,
+    tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast,
+    query_col_name: str,
+    passage_col_name: str,
 ) -> Dict[str, torch.Tensor]:
-    queries = examples["question"]
-    result_ = tokenizer(queries, padding="max_length", max_length=512, truncation=True)
+    query_list = examples[query_col_name]
+    queries = [f"#query# {query}" for query in query_list]
+    result_ = tokenizer(queries, padding="max_length", max_length=128, truncation=True)
     result_ = {f"query_{k}": v for k, v in result_.items()}
 
-    passage = examples["Abstract"]
-    result_passage = tokenizer(passage, padding="max_length", max_length=512, truncation=True)
+    passage_list = examples[passage_col_name]
+    passages = [f"#passage# {passage}" for passage in passage_list]
+    result_passage = tokenizer(passages, padding="max_length", max_length=128, truncation=True)
     for k, v in result_passage.items():
         result_[f"passage_{k}"] = v
 


### PR DESCRIPTION
- Use bits and bytes to reduce model size.
- move PEFT config inside the model to be consistent with the e2e RAG.
- Remove hardcoded values. Add command line arguments to make the script generic. Be able to train with different datasets.
- Reduce tokenizer max length to 128. Our current data is less than 100 words. (Maybe this should also be configurable via command line).