### PR TITLE
Fix for accelerate hook inputs load and save

### DIFF
--- a/dalm/eval/eval_rag.py
+++ b/dalm/eval/eval_rag.py
@@ -70,13 +70,13 @@ def parse_args() -> Namespace:
         "--retriever_peft_model_path",
         type=str,
         help="Path to the finetunned retriever peft layers",
-        required=True,
+        required=False,
     )
     parser.add_argument(
         "--generator_peft_model_path",
         type=str,
         help="Path to the finetunned generator peft layers",
-        required=True,
+        required=False,
     )
     parser.add_argument(
         "--test_batch_size",
@@ -141,7 +141,7 @@ def main() -> None:
 
     # rag retriver and the generator (don't load new peft layers no need)
     rag_model = AutoModelForRagE2E(
-        args.retriever_model_name_or_path, args.generator_model_name_or_path, get_peft=False, use_bnb=False
+        args.retriever_model_name_or_path, args.generator_model_name_or_path, get_peft=None, use_bnb=None
     )
 
     # load the test dataset

--- a/dalm/eval/eval_retriever_only.py
+++ b/dalm/eval/eval_retriever_only.py
@@ -63,7 +63,7 @@ def parse_args() -> Namespace:
         "--retriever_peft_model_path",
         type=str,
         help="Path to the finetunned retriever peft layers",
-        required=True,
+        required=False,
     )
     parser.add_argument(
         "--test_batch_size",
@@ -149,8 +149,9 @@ def main() -> None:
         pin_memory=True,
     )
 
-    # peft config and wrapping
-    retriever_model.attach_pre_trained_peft_layers(args.retriever_peft_model_path, args.device)
+    if args.retriever_peft_model_path is not None:
+        # peft config and wrapping
+        retriever_model.attach_pre_trained_peft_layers(args.retriever_peft_model_path, args.device)
 
     def get_query_embeddings(
         retriever_query_input_ids: torch.Tensor,

--- a/dalm/training/retriever_only/train_retriever_only.py
+++ b/dalm/training/retriever_only/train_retriever_only.py
@@ -159,7 +159,12 @@ def parse_args() -> Namespace:
     parser.add_argument(
         "--use_peft",
         action="store_true",
-        help="Whether to enable experiment trackers for logging.",
+        help="Whether to enable parameter efficient fine tuning",
+    )
+    parser.add_argument(
+        "--use_bnb",
+        action="store_true",
+        help="Whether to use model quantization.",
     )
     args = parser.parse_args()
 
@@ -196,14 +201,16 @@ def main() -> None:
             os.makedirs(args.output_dir, exist_ok=True)
     accelerator.wait_for_everyone()
 
-    model = AutoModelForSentenceEmbedding(args.model_name_or_path, use_bnb=True, get_peft=args.use_peft)
+    model = AutoModelForSentenceEmbedding(args.model_name_or_path, use_bnb=args.use_bnb, get_peft=args.use_peft)
     tokenizer = model.tokenizer
 
     # dataset download and preprocessing
 
-    dataset = datasets.load_dataset(
-        "csv", data_files={"train": args.train_dataset_csv_path, "validation": args.test_dataset_csv_path}
-    )
+    datafiles = {"train": args.train_dataset_csv_path}
+    if args.test_dataset_csv_path is not None:
+        datafiles["validation"] = args.test_dataset_csv_path
+
+    dataset = datasets.load_dataset("csv", data_files=datafiles)
 
     processed_datasets = dataset.map(
         lambda example: preprocess_dataset(
@@ -223,7 +230,8 @@ def main() -> None:
     for index in random.sample(range(len(processed_datasets["train"])), 3):
         logger.info(f"Sample {index} of the training set: {processed_datasets['train'][index]}.")
 
-    model.print_trainable_parameters()  # type: ignore # No idea what mypy is complaining about.
+    if args.use_peft:
+        model.print_trainable_parameters()  # type: ignore # No idea what mypy is complaining about.
 
     accelerator.print(model)
 
@@ -251,11 +259,6 @@ def main() -> None:
         num_training_steps=args.max_train_steps,
     )
 
-    # Prepare everything with our `accelerator`.
-    model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-        model, optimizer, train_dataloader, lr_scheduler
-    )
-
     # We need to recalculate our total training steps as the size of the training dataloader may have changed
     num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
     if overrode_max_train_steps:
@@ -278,10 +281,9 @@ def main() -> None:
 
     total_batch_size = args.per_device_train_batch_size * accelerator.num_processes * args.gradient_accumulation_steps
 
-    if args.use_peft:
-        # saving and loading checkpoints for resuming training
-        accelerator.register_save_state_pre_hook(save_model_hook)
-        accelerator.register_load_state_pre_hook(load_model_hook)
+    # saving and loading checkpoints for resuming training
+    accelerator.register_save_state_pre_hook(save_model_hook)
+    accelerator.register_load_state_pre_hook(load_model_hook)
 
     logger.info("***** Running training *****")
     logger.info(f"  Num examples = {len(processed_datasets['train'])}")
@@ -318,7 +320,12 @@ def main() -> None:
             resume_step = int(training_difference.replace("step_", "")) * args.gradient_accumulation_steps
             starting_epoch = resume_step // len(train_dataloader)
             resume_step -= starting_epoch * len(train_dataloader)
-            completed_steps = resume_step // args.gradient_accumulation_step
+            completed_steps = resume_step // args.gradient_accumulation_steps
+
+    # Prepare everything with our `accelerator`.
+    model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+        model, optimizer, train_dataloader, lr_scheduler
+    )
 
     # update the progress_bar if load from checkpoint
     progress_bar.update(completed_steps)

--- a/dalm/training/utils/train_utils.py
+++ b/dalm/training/utils/train_utils.py
@@ -27,19 +27,39 @@ def load_model_hook(models: List[AutoModel], input_dir: str) -> None:
         model = models.pop()
         # pop models so that they are not loaded again
         if isinstance(model, AutoModelForRagE2E):
-            if hasattr(model.generator_model, "active_adapter") and hasattr(model.generator_model, "load_adapter"):
-                generator_path = os.path.join(input_dir, "generator")
-                model.generator_model.load_adapter(
-                    generator_path, model.generator_model.active_adapter, is_trainable=True
-                )
-            if hasattr(model.retriever_model, "active_adapter") and hasattr(model.retriever_model, "load_adapter"):
-                retriever_path = os.path.join(input_dir, "retriever")
-                model.retriever_model.load_adapter(
-                    retriever_path, model.retriever_model.active_adapter, is_trainable=True
-                )
+            generator_path = os.path.join(input_dir, "generator")
+            adapter_model_path = os.path.join(generator_path, "adapter_model.bin")
+
+            if (
+                hasattr(model.generator_model, "active_adapter")
+                and hasattr(model.generator_model, "load_adapter")
+                and os.path.exists(adapter_model_path)
+            ):
+                model.generator_model.load_adapter(generator_path, model.generator_model.active_adapter)
+            else:
+                model.generator_model = AutoModel.from_pretrained(generator_path)
+
+            retriever_path = os.path.join(input_dir, "retriever")
+            adapter_model_path = os.path.join(generator_path, "adapter_model.bin")
+
+            if (
+                hasattr(model.retriever_model, "active_adapter")
+                and hasattr(model.retriever_model, "load_adapter")
+                and os.path.exists(adapter_model_path)
+            ):
+                model.retriever_model.load_adapter(retriever_path, model.retriever_model.active_adapter)
+            else:
+                model.retriever_model = AutoModel.from_pretrained(retriever_path)
         elif isinstance(model, AutoModelForSentenceEmbedding):
-            if hasattr(model.model, "active_adapter") and hasattr(model, "load_adapter"):
-                model.model.load_adapter(input_dir, model.model.active_adapter, is_trainable=True)
+            adapter_model_path = os.path.join(input_dir, "adapter_model.bin")
+            if (
+                hasattr(model.model, "active_adapter")
+                and hasattr(model, "load_adapter")
+                and os.path.exists(adapter_model_path)
+            ):
+                model.model.load_adapter(input_dir, model.model.active_adapter)
+            else:
+                model.model = AutoModel.from_pretrained(input_dir)
         else:
             model.load_adapter(input_dir, model.active_adapter, is_trainable=True)
 


### PR DESCRIPTION
Hopes to close #50 

### Changes
1. save and load functions that serve as inputs to accelerate save and load hooks now saves and loads model states according to model type. There is now filtering to make sure e2e weights get segregated according to model subtype (generator, retriever)
2. the above mentioned is no longer exclusive to Peft. Special care was taken to make sure no model weight prefix bug pops up while saving and loading non-peft weights (this was done by making sure prefix was taken off while saving model weights)
3. cli flags is now made flexible for control bnb and peft enabling for retriever and/or generator
4. in the `dalm/training/retriever_only/train_retriever_only.py` is constructed explicitly as ohterwise would lead to weird bytestring and str additions erros

### Testing
1. trained and evaluated for e2e locally (peft retriever and non-peft generator) 
2.  trained and evaluated for retriever only (peft and no peft)
