### PR TITLE
Configure generator tokenizer to add <eos> token 

### DIFF
--- a/dalm/training/rag_e2e/train_rage2e.py
+++ b/dalm/training/rag_e2e/train_rage2e.py
@@ -258,6 +258,9 @@ def main() -> None:
     generator_tokenizer = rag_model.generator_tokenizer
     generator_tokenizer.pad_token = generator_tokenizer.eos_token
 
+    # TODO: check if this is depdendent on the tokenizer installed
+    generator_tokenizer.add_eos_token = True
+
     processed_datasets = dataset.map(
         lambda example: preprocess_dataset(
             example,


### PR DESCRIPTION
## Test outputs sample:

info: `2` is the `eos_token_id` as well as `pad_token_id`

Tokenized generator input
```
tensor([[    1,   396,  1972, 29937,   396,  1972, 29937,  1724,  1122,   367,
          5134,   297,   263,  2479,  4742, 29973,   396,  3364,   482, 29937,
           396,  3364,   482, 29937,   319,  2479,  4742,  1122,  3160,   263,
          7182,  4701,   304,   671,   263,  4520,  1967,  7182,   304,  5706,
          4004,   284,  1967, 18470, 29892,   304,  8161,   263,  5665,   363,
         16384,  4004,   284,  4558,   393,  8307,  3928,   304,   278,  4004,
           284,  1967, 18470, 29892,   322,   304,   671,   278,  4004,   284,
          1967, 18470,   304,  5706,   385,  1967,   848,  7182, 29889,   450,
          4004,   284,  4558,  1122,  3160,   263,  2246,  2175,  1967, 29892,
           263,  5970,  2175,  1967, 29892,   263,  2246,  1492,  1967, 29892,
           322,   263,  5970,  1492,  1967, 29889,   450,  4742,  1122,  4340,
          3160,   263,  2479,  9451,   304,  2479,   278,  4004,   284,  4558,
          5034,   304,   848, 18470,  5759,  2729,   373,   278,  1967,   848,
          7182,   322,  5034,   304,   278,  5665, 29889,   450,   396, 12011,
         29937,   263,  7182,  4701,     2,     2,     2,     2,     2,     2,
             2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
             2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
             2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
             2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
             2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
             2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
             2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
             2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
             2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
             2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
             2,     2,     2,     2,     2,     2]], device='cuda:0')
```

Calculated mask

```
tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], device='cuda:0')
```
Tokenized input * mask

```
tensor([[    1,   396,  1972, 29937,   396,  1972, 29937,  1724,  1122,   367,
          5134,   297,   263,  2479,  4742, 29973,   396,  3364,   482, 29937,
           396,  3364,   482, 29937,   319,  2479,  4742,  1122,  3160,   263,
          7182,  4701,   304,   671,   263,  4520,  1967,  7182,   304,  5706,
          4004,   284,  1967, 18470, 29892,   304,  8161,   263,  5665,   363,
         16384,  4004,   284,  4558,   393,  8307,  3928,   304,   278,  4004,
           284,  1967, 18470, 29892,   322,   304,   671,   278,  4004,   284,
          1967, 18470,   304,  5706,   385,  1967,   848,  7182, 29889,   450,
          4004,   284,  4558,  1122,  3160,   263,  2246,  2175,  1967, 29892,
           263,  5970,  2175,  1967, 29892,   263,  2246,  1492,  1967, 29892,
           322,   263,  5970,  1492,  1967, 29889,   450,  4742,  1122,  4340,
          3160,   263,  2479,  9451,   304,  2479,   278,  4004,   284,  4558,
          5034,   304,   848, 18470,  5759,  2729,   373,   278,  1967,   848,
          7182,   322,  5034,   304,   278,  5665, 29889,   450,   396, 12011,
         29937,   263,  7182,  4701,     2,     0,     0,     0,     0,     0,
             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
             0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
             0,     0,     0,     0,     0,     0]], device='cuda:0')
```