### PR TITLE
Bump up default max_lengths for generation and passage lengths

### DIFF
--- a/dalm/eval/eval_rag.py
+++ b/dalm/eval/eval_rag.py
@@ -48,7 +48,7 @@ def parse_args() -> Namespace:
     parser.add_argument(
         "--max_length",
         type=int,
-        default=128,
+        default=256,
         help=(
             "The maximum total input sequence length after tokenization. Sequences longer than this will be truncated,"
             " sequences shorter will be padded if `--pad_to_max_length` is passed."
@@ -119,7 +119,7 @@ def parse_args() -> Namespace:
 
 
 def run_generator_on_prompts(
-    model: PreTrainedModel, tokenizer: PreTrainedTokenizer, prompts: List[str], max_length: int = 200
+    model: PreTrainedModel, tokenizer: PreTrainedTokenizer, prompts: List[str], max_length: int = 256
 ) -> List[str]:
     """Runs the generator model over the prompts (query + passage)"""
     # TODO: Is the max_length correct here? not sure

--- a/dalm/training/rag_e2e/train_rage2e.py
+++ b/dalm/training/rag_e2e/train_rage2e.py
@@ -82,7 +82,7 @@ def parse_args() -> Namespace:
     parser.add_argument(
         "--passage_max_len",
         type=int,
-        default=128,
+        default=160,
         help=(
             "The maximum total passage sequence length after tokenization. Sequences longer than this will be truncated,"
         ),

--- a/dalm/training/retriever_only/train_retriever_only.py
+++ b/dalm/training/retriever_only/train_retriever_only.py
@@ -65,7 +65,7 @@ def parse_args() -> Namespace:
     parser.add_argument(
         "--passage_max_len",
         type=int,
-        default=128,
+        default=160,
         help=(
             "The maximum total passage sequence length after tokenization. Sequences longer than this will be truncated,"
         ),


### PR DESCRIPTION
Based on p95s of tokenized training and test data

| type |  current length | p95 length  |
| ------  | -------------- | ------------------- |
Causal text | 256 | 209 |
query | 50 | 26
passage | 128 | 160

Seem reasonable that only passage length's default  be increased from 128 to 160

Causal text length has been modified to be consistent elsewhere