### PR TITLE
Fixes #68 by using a version range for typer library

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ python dalm/training/rag_e2e/train_rage2e.py \
   --report_to all \
   --per_device_train_batch_size 20
 ```
+
 or
+
 ```shell
 dalm train-rag-e2e \
 "./dalm/datasets/toy_data_train.csv" \

--- a/README.md
+++ b/README.md
@@ -107,9 +107,7 @@ python dalm/training/rag_e2e/train_rage2e.py \
   --report_to all \
   --per_device_train_batch_size 20
 ```
-
 or
-
 ```shell
 dalm train-rag-e2e \
 "./dalm/datasets/toy_data_train.csv" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "peft",
     "diffusers",
     "bitsandbytes",
-    "typer",
+    "typer>=0.9.0,<1.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This fixes #68 by requiring a newer version of typer.  It fixes the version at the current major version in case there are any breaking changes in the next major version of typer.  

I'm assuming typer is using [semantic versioning](https://semver.org/) and won't make any api incompatible breaking changes in minor or patch versions.

## Testing

```
$ conda create --name update_typer_lib python=3.11
$ conda activate update_typer_lib
$ pip install git+https://github.com/tleyden/DALM.git@7f581a2ba4eb9#egg=indomain
$ dalm
Usage: dalm [OPTIONS] COMMAND [ARGS]...
Try 'dalm --help' for help.
$ pip list | grep -i typer
typer                    0.9.0
```