### PR TITLE
Return evaluation results to callers

### DIFF
--- a/dalm/eval/eval_results.py
+++ b/dalm/eval/eval_results.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class EvalResults(BaseModel):
+    total_examples: int
+    recall: float
+    precision: float
+    hit_rate: float

--- a/dalm/eval/eval_retriever_only.py
+++ b/dalm/eval/eval_retriever_only.py
@@ -10,6 +10,8 @@ import torch
 
 from datasets import Dataset
 from torch.utils.data import DataLoader
+from dalm.eval.eval_results import EvalResults
+
 
 from dalm.eval.utils import (
     construct_search_index,
@@ -18,6 +20,7 @@ from dalm.eval.utils import (
     get_passage_embeddings,
     evaluate_retriever_on_batch,
     print_eval_results,
+    calc_eval_results,
 )
 from dalm.models.retriever_only_base_model import AutoModelForSentenceEmbedding
 from dalm.utils import load_dataset
@@ -112,7 +115,7 @@ def evaluate_retriever(
     torch_dtype: Literal["float16", "bfloat16"] = "float16",
     top_k: int = 10,
     is_autoregressive: bool = False,
-) -> None:
+) -> EvalResults:
     """Runs rag evaluation. See `dalm eval-retriever --help for details on params"""
     test_dataset = load_dataset(dataset_or_path)
     selected_torch_dtype: Final[torch.dtype] = torch.float16 if torch_dtype == "float16" else torch.bfloat16
@@ -170,7 +173,9 @@ def evaluate_retriever(
         batch_recall.extend(_batch_recall)
         total_hit += _total_hit
 
-    print_eval_results(len(processed_datasets), batch_precision, batch_recall, total_hit)
+    eval_results = calc_eval_results(len(processed_datasets), batch_precision, batch_recall, total_hit)
+    print_eval_results(eval_results)
+    return eval_results
 
 
 def main() -> None:

--- a/dalm/eval/utils.py
+++ b/dalm/eval/utils.py
@@ -10,6 +10,8 @@ from torch.utils.data import DataLoader
 from tqdm.auto import tqdm
 from transformers import PreTrainedTokenizer, default_data_collator
 
+from dalm.eval.eval_results import EvalResults
+
 logger = logging.getLogger(__name__)
 
 
@@ -270,18 +272,24 @@ def evaluate_retriever_on_batch(
     return batch_precision, batch_recall, total_hit, top_passages
 
 
-def print_eval_results(
+def calc_eval_results(
     total_examples: int,
     precisions: list[float],
     recalls: list[float],
     total_hit: int,
-) -> None:
+) -> EvalResults:
     precision = sum(precisions) / total_examples
     recall = sum(recalls) / total_examples
     hit_rate = total_hit / float(total_examples)
 
+    return EvalResults(total_examples=total_examples, recall=recall, precision=precision, hit_rate=hit_rate)
+
+
+def print_eval_results(
+    eval_results: EvalResults,
+) -> None:
     logger.info("Retriever results:")
-    logger.info(f"Recall: {recall}")
-    logger.info(f"Precision: {precision}")
-    logger.info(f"Hit Rate: {hit_rate}")
+    logger.info(f"Recall: {eval_results.recall}")
+    logger.info(f"Precision: {eval_results.precision}")
+    logger.info(f"Hit Rate: {eval_results.hit_rate}")
     logger.info("*************")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "diffusers",
     "bitsandbytes",
     "typer>=0.9.0,<1.0",
-    "pydantic>=2.4.2,<3.0",
+    "pydantic==1.10.9",  # Sync w/ other platform components
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "diffusers",
     "bitsandbytes",
     "typer>=0.9.0,<1.0",
+    "pydantic>=2.4.2,<3.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
In order for callers to use the evaluation results, for example displaying them in a UI, the evaluation functions should return these results to the caller.

This PR:

1. Defines a container class for the eval results
2. Decouples the calculation and printing of eval results
3. Returns eval results as a container class instance

It uses [Pydantic](https://docs.pydantic.dev/latest/) for the container class in case we later need to use validation or any other features offered by pydantic.  It requires the same pydantic version as used in the Arcee platform.

## Testing

Manually tested, here is output:

```
10/25/2023 10:53:29 - INFO - dalm.eval.eval_retriever_only - Construct passage index
10/25/2023 10:53:29 - INFO - dalm.eval.eval_retriever_only - Evaluation start
10/25/2023 10:53:30 - INFO - dalm.eval.utils - Retriever results:
10/25/2023 10:53:30 - INFO - dalm.eval.utils - Recall: 0.883495145631068
10/25/2023 10:53:30 - INFO - dalm.eval.utils - Precision: 0.08834951456310675
10/25/2023 10:53:30 - INFO - dalm.eval.utils - Hit Rate: 0.883495145631068
10/25/2023 10:53:30 - INFO - dalm.eval.utils - *************
10/25/2023 10:53:30 - INFO - root - Retriever evaluation results: total_examples=206 recall=0.883495145631068 precision=0.08834951456310675 hit_rate=0.883495145631068
```