### PR TITLE
Added fix in model eval to move RAG generator and retriever to current device

### DIFF
--- a/dalm/eval/eval_rag.py
+++ b/dalm/eval/eval_rag.py
@@ -196,6 +196,11 @@ def evaluate_rag(
     )
     # peft config and wrapping
     rag_model.attach_pre_trained_peft_layers(retriever_peft_model_path, generator_peft_model_path, device)
+
+    #move retriever and generator to appropriate device
+    rag_model.retriever_model.eval().to(device)
+    rag_model.generator_model.eval().to(device)
+
     unique_passage_dataset, passage_embeddings_array = get_passage_embeddings(
         processed_datasets,
         passage_column_name,


### PR DESCRIPTION
When not using peft, the `evaluate_rag` function fails with an error stating that the the model is not on the correct device('cuda', 'cpu')

This fix verifies that the model's generator and retriever are both on the same device
cc @shamanez 