### PR TITLE
Workaround hatchling backwards incompatibility issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling<=1.18.0"]
 build-backend = "hatchling.build"
 
 


### PR DESCRIPTION
The root cause is documented here: https://github.com/pypa/hatch/issues/1113